### PR TITLE
Replace wrong quoting strategy

### DIFF
--- a/src/QueryBuilder/Visitor/Parameters/StringReplacingStrategy.php
+++ b/src/QueryBuilder/Visitor/Parameters/StringReplacingStrategy.php
@@ -11,6 +11,6 @@ class StringReplacingStrategy implements ReplacingStrategyInterface
 
     public function replace($value): string
     {
-        return sprintf('\'%s\'', preg_quote($value, '\''));
+        return sprintf('\'%s\'', str_replace(['\\', '\''], ['\\\\\\', '\\\''], $value));
     }
 }


### PR DESCRIPTION
`preg_quote` does also replace "." thus leading to a invalid replacing for the API.